### PR TITLE
fixup 2018 geocoder

### DIFF
--- a/data/2018/hardcoded_locations.js
+++ b/data/2018/hardcoded_locations.js
@@ -1,0 +1,34 @@
+module.exports = {
+  "Esplanade & 5:45": { 
+    type: 'Feature',
+    properties: {},
+    geometry:
+     { type: 'Point',
+       coordinates: [ -119.21134185791016, 40.78132629394531 ] 
+     } 
+  },
+  "Rte 66 Qrtr Two @ 6:30": { 
+    type: 'Feature',
+    properties: {},
+    geometry:
+     { type: 'Point',
+       coordinates: [ -119.21534729003906, 40.781890869140625 ]  
+     } 
+  },
+  "C & 6:15": {
+    type: 'Feature',
+    properties: {},
+    geometry:
+     { type: 'Point',
+       coordinates: [ -119.21671295166016, 40.7811164855957 ]
+     }
+  },
+  "Airport Road & Airport Road": {
+    type: 'Feature',
+    properties: {},
+    geometry:
+     { type: 'Point',
+       coordinates: [ -119.21112060546875, 40.76435470581055 ]
+     }
+  }
+}

--- a/data/2018/layouts/layout-single-letter.json
+++ b/data/2018/layouts/layout-single-letter.json
@@ -224,6 +224,12 @@
       "time":"12:00",
       "distance": 0,
       "diameter": 400
+    },
+    {
+      "name":"Center Camp Plaza",
+      "time":"6:00",
+      "distance":"a",
+      "diameter": 600
     }
   ],
   "portals":[

--- a/data/2018/layouts/layout.json
+++ b/data/2018/layouts/layout.json
@@ -224,6 +224,12 @@
       "time":"12:00",
       "distance": 0,
       "diameter": 400
+    },
+    {
+      "name":"Center Camp Plaza",
+      "time":"6:00",
+      "distance":"a",
+      "diameter": 600
     }
   ],
   "portals":[

--- a/scripts/latest/geocoder/forward.js
+++ b/scripts/latest/geocoder/forward.js
@@ -39,7 +39,7 @@ Geocoder.prototype.streetIntersectionToLatLon = function(timeString, featureName
   featureName = featureName.toLowerCase();
   var timeBearing = utils.timeStringToCompaassDegress(timeString,this.cityBearing);
   var start = this.centerPoint;
-  if (featureName.indexOf("rod") > -1 ||featureName.indexOf("inner") > -1 || featureName.indexOf("66") > -1) {
+  if (featureName.indexOf("rod") > -1 ||featureName.indexOf("inner") > -1 || featureName.indexOf("66") > -1 || featureName.indexOf("center camp") > -1) {
     start = this.centerCamp;
   }
 
@@ -110,7 +110,7 @@ function intersectingPoints(features1,features2) {
 
 Geocoder.prototype.geocode = function(locationString) {
   if (locationString in this.hardcodedLocations) {
-    return this.hardcodedLocations[locationStirng]
+    return this.hardcodedLocations[locationString]
   } else {
     var coder = this;
     var result = Parser.parse(locationString);

--- a/scripts/latest/geocoder/geocodeParser.js
+++ b/scripts/latest/geocoder/geocodeParser.js
@@ -21,7 +21,7 @@ module.exports.parse = function(string) {
   //Distance regex 100'
   var feetRegEx = new RegExp("[0-9]*(?=')");
   //featureRegEx captures streets A-L Rod's road and plazas when they begin the string and are followed by ' &' or are at the end
-  var featureRegEx = new RegExp("(^[a-l|rod|p].*)|(^.*plaza.*$)");
+  var featureRegEx = new RegExp("(^[a-l|rod|p|center].*)|(^.*[plaza|portal].*$)");
 
   var split = string.split(/(?: @|&)/);
   if (split.length > 1) {

--- a/scripts/latest/geocoder/geocoder.js
+++ b/scripts/latest/geocoder/geocoder.js
@@ -1,11 +1,12 @@
 var forwardGeocoder = require('./forward.js');
+var hardcodedLocations = require('../../../data/2018/hardcoded_locations.js');
 var reverseGeocoder = require('./reverse.js')
 var prepare = require('./prepare.js');
 
 var Geocoder = function(layoutFile) {
   var dict = prepare(layoutFile)
   this.reverseCoder = new reverseGeocoder(dict.center,dict.centerCamp,dict.bearing,dict.reversePolygons,dict.reverseStreets);
-  this.forwardCoder = new forwardGeocoder(dict.center,dict.centerCamp,dict.bearing,dict.forwardStreets,dict.forwardPolygons);
+  this.forwardCoder = new forwardGeocoder(dict.center,dict.centerCamp,dict.bearing,dict.forwardStreets,dict.forwardPolygons, hardcodedLocations);
 }
 
 // Legacy Android (pre 4.4) Javascript bridge only accepts primitives


### PR DESCRIPTION
This should fix all issues in #9 
+ Parse “Portal” features
+ Add and parse “Center Camp Plaza” plaza feature
+ Add 2018 hardcoded locations. These are all technically invalid but
decipherable addresses that require wetware interpretation